### PR TITLE
Fix the leipzig parser

### DIFF
--- a/scripts/travis-install-deps.sh
+++ b/scripts/travis-install-deps.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -ex
 apt-get update -qq
-apt-get install -qq python3 python3-bs4 uwsgi uwsgi-plugin-python3 devscripts debhelper
+apt-get install -qq python3 python3-bs4 python3-lxml uwsgi uwsgi-plugin-python3 devscripts debhelper


### PR DESCRIPTION
The Studentenwerk Leipzig recently launched a new website that broke the old parser, which relied on an ajax api that was used in the old website. The new one offers a dedicated [xml API](https://www.studentenwerk-leipzig.de/XMLInterface/request).

I also fixed a problem of the previous parser which added every component of a meal as a separate meal.

Note that I used BeautifulSoup for parsing the xml, so `lxml` is needed. It seems the debian package already specifies this requirement, but it was missing from the travis config.