### PR TITLE
Fix shebangs

### DIFF
--- a/aachen.py
+++ b/aachen.py
@@ -1,4 +1,3 @@
-#!python3
 from urllib.request import urlopen
 from bs4 import BeautifulSoup as parse
 from bs4.element import NavigableString, Tag

--- a/chemnitz_zwickau.py
+++ b/chemnitz_zwickau.py
@@ -1,4 +1,3 @@
-#!python3
 from bs4 import BeautifulSoup
 from urllib.request import urlopen
 import datetime

--- a/dresden.py
+++ b/dresden.py
@@ -1,4 +1,3 @@
-#!python3
 from urllib.request import urlopen
 from bs4 import BeautifulSoup as parse
 import re

--- a/erlangen_nuernberg.py
+++ b/erlangen_nuernberg.py
@@ -1,4 +1,3 @@
-#!python3
 from urllib.request import *
 
 import time

--- a/halle.py
+++ b/halle.py
@@ -1,4 +1,3 @@
-#!python3
 import re
 import datetime
 

--- a/hamburg.py
+++ b/hamburg.py
@@ -1,4 +1,3 @@
-#!python3
 from urllib.request import urlopen
 from bs4 import BeautifulSoup as parse
 import re

--- a/hannover.py
+++ b/hannover.py
@@ -1,4 +1,3 @@
-#!python3
 from urllib.request import urlopen
 import re
 from xml.dom.minidom import Document

--- a/karlsruhe.py
+++ b/karlsruhe.py
@@ -1,4 +1,3 @@
-#!python3
 from urllib.request import urlopen
 from bs4 import BeautifulSoup as parse
 import re

--- a/leipzig.py
+++ b/leipzig.py
@@ -1,4 +1,3 @@
-#!python3
 from urllib.request import urlopen
 from bs4 import BeautifulSoup
 import datetime

--- a/magdeburg.py
+++ b/magdeburg.py
@@ -1,4 +1,3 @@
-#!python3
 from urllib.request import urlopen
 from bs4 import BeautifulSoup as parse
 import re

--- a/marburg.py
+++ b/marburg.py
@@ -1,4 +1,3 @@
-#!python3
 from urllib.request import urlopen
 from bs4 import BeautifulSoup as parse
 from bs4.element import Tag

--- a/muenchen.py
+++ b/muenchen.py
@@ -1,4 +1,3 @@
-#!python3
 from urllib.request import urlopen
 from urllib.error import HTTPError
 from bs4 import BeautifulSoup as parse

--- a/niederbayern_oberpfalz.py
+++ b/niederbayern_oberpfalz.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 #  niederbayern_oberpfalz.py

--- a/ostniedersachsen.py
+++ b/ostniedersachsen.py
@@ -1,4 +1,3 @@
-#!python3
 import re
 from urllib.request import urlopen
 from bs4 import BeautifulSoup as parse

--- a/parse.py
+++ b/parse.py
@@ -1,4 +1,4 @@
-#!python3
+#!/usr/bin/env python3
 import sys
 
 from config import parse

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,3 @@
-#!python3
 import os.path
 from urllib.request import urlopen
 from urllib.parse import urlencode

--- a/wsgihandler.py
+++ b/wsgihandler.py
@@ -1,4 +1,3 @@
-#!python3
 import sys
 import traceback
 import re

--- a/wuerzburg.py
+++ b/wuerzburg.py
@@ -1,4 +1,3 @@
-#!python3
 from urllib.request import urlopen
 from bs4 import BeautifulSoup as parse
 import re


### PR DESCRIPTION
This removes all unneeded shebangs from the parser files (that didn't work anyway) and fixes the shebang for `parse.py` so it can be called directly:

```
./parse.py leipzig am-park today.xml
```