### PR TITLE
WIP: Validate documents against the openmensa schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ As many meal information are only available online as HTML, [Beautiful Soup 4](h
 2. Install the dependecies:
    * [Python 3](https://www.python.org/)
    * [Beautiful Soup 4](http://www.crummy.com/software/BeautifulSoup/) - needed for most parsers/providers.
-   * [python-lxml](http://lxml.de/) Some parsers using the `lxml` backend of Beautiful Soup, so you might need the Python `lxml` module/extension.
+   * [lxml](http://lxml.de/) - validating the generated documents and (as a bs4 backend) consuming xml APIs
 
 3. Try some parsers
 

--- a/open-mensa-v2.xsd
+++ b/open-mensa-v2.xsd
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://openmensa.org/open-mensa-v2" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://openmensa.org/open-mensa-v2" elementFormDefault="qualified">
+
+    <xs:element name="openmensa" type="openmensaType"></xs:element>
+    
+    <xs:complexType name="openmensaType">
+        <xs:annotation>
+            <xs:documentation>This is the required OpenMense root element always accompanied by a version attribute that explicitly tells the feed's version to the parser.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="version" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Defines the version of the parser. It has nothing to do with the canteen or its menu.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="0"></xs:minLength>
+                        <xs:maxLength value="63"></xs:maxLength>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="canteen" type="canteenType" minOccurs="1" maxOccurs="1"></xs:element>
+        </xs:sequence>
+        <xs:attribute name="version" use="required">
+            <xs:annotation>
+                <xs:documentation>The version should be equal to 2.0 or 2.1.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:float">
+                    <xs:enumeration value="2.0"></xs:enumeration>
+                    <xs:enumeration value="2.1"></xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="canteenType">
+        <xs:annotation>
+            <xs:documentation>This stands for a single canteen.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Metadata: the canteen name</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="address" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Metadata: the (postal) address</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="city" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Metadata: the user-relevant city of this canteen</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="phone" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Metadata: the phone number to contact the canteen (we highly recommend following the E.123 standard)</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="email" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Metadata: the email address to contact the canteen (we highly recommend following the E.123 standard)</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="location" type="locationType" minOccurs="0" maxOccurs="1" >
+                <xs:annotation>
+                    <xs:documentation>Metadata: the physical location of the canteen</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="availability" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Metadata: indicate whether the canteen can be used by everyone (public) or not (restricted)</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="public"></xs:enumeration>
+                        <xs:enumeration value="restricted"></xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="times" type="timesType" minOccurs="0" maxOccurs="1"></xs:element>
+            <xs:element name="feed" type="feedType" minOccurs="0" maxOccurs="unbounded"></xs:element>
+            <xs:element name="day" type="dayType" maxOccurs="unbounded" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>All meals of all categories are grouped by day. There may be no day elements at all - that's ok because for some days there are no meals.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="dayType">
+        <xs:choice>
+            <xs:element name="category" type="categoryType" maxOccurs="unbounded" minOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Every meal must belong to a category so there should be at least one category since a day without any meals may be omitted completely else.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="closed">
+                <xs:annotation>
+                    <xs:documentation>Indicates that for the given day a canteen has closed (to distinguish from the case where there is - for some reason - no data). Should be used on weekends or explicit closing times on holidays.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="0"></xs:maxLength>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:choice>
+        <xs:attribute name="date" use="required">
+            <xs:annotation>
+                <xs:documentation>This field specifies the date of the day as "YYYY-MM-DD.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:pattern value="[0-9]{4,4}-[0-9]{2,2}-[0-9]{2,2}"></xs:pattern>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="categoryType">
+        <xs:sequence>
+            <xs:element name="meal" type="mealType" maxOccurs="unbounded" minOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Each category must contain at least one meal because else the category is useless.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>The name of the category, e.g. "Essen 1" or "Ausgabe A".</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="1"></xs:minLength>
+                    <xs:maxLength value="250"></xs:maxLength>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="mealType">
+        <xs:sequence>
+            <xs:element name="name">
+                <xs:annotation>
+                    <xs:documentation>The name of the meal, e.g. "Rinderhacksteak mit Kartoffeln". Shouldn't be more than a couple of words or a sentence in maximum. Additional text may go into several notes.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="1"></xs:minLength>
+                        <xs:maxLength value="250"></xs:maxLength>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="note" maxOccurs="unbounded" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>A note often resembles a properties of the associated meal like the ingredients used or some important annotations.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="1"></xs:minLength>
+                        <xs:maxLength value="250"></xs:maxLength>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="price" maxOccurs="unbounded" minOccurs="0" type="priceType">
+                <xs:annotation>
+                    <xs:documentation>This field contains a price in euro for a given role (because different prices may apply different groups of people). There mustn't be two price elements with the same role for a meal!</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="priceType">
+        <xs:simpleContent>
+            <xs:extension base="xs:float">
+                <xs:attribute name="role" use="required">
+                    <xs:annotation>
+                        <xs:documentation>A price's role defines for which group of persons the price is valid:
+- pupils (some canteens do that)
+- students
+- employees (of your organization) or
+- others (people that do not belong to your organization or to any other group listed here).</xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="pupil"></xs:enumeration>
+                            <xs:enumeration value="student"></xs:enumeration>
+                            <xs:enumeration value="employee"></xs:enumeration>
+                            <xs:enumeration value="other"></xs:enumeration>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="locationType">
+        <xs:attribute name="latitude" type="xs:float" use="required"></xs:attribute>
+        <xs:attribute name="longitude" type="xs:float" use="required"></xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="timesType">
+        <xs:sequence>
+            <xs:element name="monday" type="weekdayType" minOccurs="0" maxOccurs="1"></xs:element>
+            <xs:element name="tuesday" type="weekdayType" minOccurs="0" maxOccurs="1"></xs:element>
+            <xs:element name="wednesday" type="weekdayType" minOccurs="0" maxOccurs="1"></xs:element>
+            <xs:element name="thursday" type="weekdayType" minOccurs="0" maxOccurs="1"></xs:element>
+            <xs:element name="friday" type="weekdayType" minOccurs="0" maxOccurs="1"></xs:element>
+            <xs:element name="saturday" type="weekdayType" minOccurs="0" maxOccurs="1"></xs:element>
+            <xs:element name="sunday" type="weekdayType" minOccurs="0" maxOccurs="1"></xs:element>
+        </xs:sequence>
+        <xs:attribute name="type" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="opening"></xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="feedType">
+        <xs:all>
+            <xs:element name="schedule" type="scheduleType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The feed is accessed if the current time matches ALL these patterns of the schedule.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:string" minOccurs="1" maxOccurs="1"></xs:element>
+            <xs:element name="source" type="xs:string" minOccurs="0" maxOccurs="1"></xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>This unique name is only used by OpenMensa to match the given feed to previously saved feed data. But we recommend to choose descriptive names.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="priority" type="xs:int" use="optional">
+            <xs:annotation>
+                <xs:documentation>The default priority is 0. A feed can update/remove a meal if the priority is same or greater than the priority of the feed that created the menu.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="scheduleType">
+        <xs:attribute name="dayOfMonth" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>Starts with 1, defaults to *.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="dayOfWeek" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>Start with 0 meaning Sunday, defaults to *.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="month" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>Defaults to *.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="hour" type="xs:string" use="required"></xs:attribute>
+        <xs:attribute name="minute" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>Defaults to 0.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="retry" use="optional">
+            <xs:annotation>
+                <xs:documentation>Without this attribute OpenMensa does not retry to fetch the feed on errors.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:pattern value="\d+\s+\d+(\s+\d+)?"></xs:pattern>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="weekdayType">
+        <xs:attribute name="open" use="optional">
+            <xs:annotation>
+                <xs:documentation>A value of HH:mm-HH:mm to specify that the canteen has open within the given time interval.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:pattern value="\d\d:\d\d-\d\d:\d\d"></xs:pattern>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="closed" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="true"></xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+</xs:schema>

--- a/parse.py
+++ b/parse.py
@@ -1,6 +1,8 @@
 #!python3
 import sys
 
+from lxml import etree
+
 from config import parse
 from utils import Request, NotFoundError
 
@@ -11,7 +13,17 @@ class SimulatedRequest(Request):
 
 
 try:
-    print(parse(SimulatedRequest(), *sys.argv[1:]))
+    document = parse(SimulatedRequest(), *sys.argv[1:])
+    print(document)
+
+    # check if the document is valid according to the schema
+    schema = etree.XMLSchema(file = "open-mensa-v2.xsd")
+    parser = etree.XMLParser(schema = schema)
+    etree.fromstring(document.encode("utf-8"), parser)
 except NotFoundError as e:
-    print(e)
+    print(e, file = sys.stderr)
     sys.exit(2)
+except etree.XMLSyntaxError as e:
+    print("The generated xml is not a valid openmensa document:", file = sys.stderr)
+    print(e, file = sys.stderr)
+    sys.exit(3)


### PR DESCRIPTION
This is useful for development, as you may not notice when the generated xml is not valid (as I did in #37).

The first commit adds validating support to `parse.py`, which makes lxml a mandatory dependency for dev.

I also think it would be useful to add validation to the travis builds, maybe by replacing the wget commands with a python script that validates the returned documents. What do you think?