### PR TITLE
Fix and refactor README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ OpenMensa Parsers
 
 [![Build Status](https://api.travis-ci.org/mswart/openmensa-parsers.svg)](https://travis-ci.org/mswart/openmensa-parsers)
 
-[OpenMensa](http://openmensa.org) is a free canteen database. It depends on external parsers that provide the meal information for the specific canteens.
+[OpenMensa] is a free canteen database. It depends on external parsers that provide the meal information for the specific canteens.
 
 This repository contains a large collection of parsers for different canteens all over Germany - mostly university canteens provided by student unions.
 
-Before you continue you may want to read the [feed documentation](http://doc.openmensa.org/feed/v2/) describing the exchange format between parsers and OpenMensa.
+Before you continue you may want to read the [feed documentation] describing the exchange format between parsers and OpenMensa.
 
 
 ## Contribute
 
-**Corrections Wellcome**: As I do not use most of the parsers myself it is likely that I miss some parsing issues. Feel free to report an issue or even better provide a pull request.
+**Corrections Welcome**: As I do not use most of the parsers myself it is likely that I miss some parsing issues. Feel free to report an issue or even better provide a pull request.
 
 **Hosting Provided**: Your canteen is missing? You could write a parser for your canteen (in Python)? But you do not know where to host the parser? I can host your parser at omfeeds.devtation.de. Please provide a PR with the new parser.
 
@@ -23,14 +23,14 @@ The parsers itself are independent. But there is a small framework handling comm
 
 Each provider has it's own Python module. A provider represents a collection of canteens which are organisationally dependent and therefore can be parsed by the same process. The module itself has to implement a `parse_url(canteenidentifier, today=False)` method. This method is called to parse and return the feed for a specific canteen. What the `canteenidentifier` is exactly is up to the provider - mostly they are URL parts or URL suffixes.
 
-The [config.py](blob/master/config.py) contains a list of all known providers and it's canteens (plus the `canteenidentifier` that is passed to the `parse_url` method). The structure is hopefully self explaining. If not, please open an issue.
+The [config.py] contains a list of all known providers and it's canteens (plus the `canteenidentifier` that is passed to the `parse_url` method). The structure is hopefully self explaining. If not, please open an issue.
 
 
 ## Common implementation details of providers
 
-At the moment all providers using [PyOpenMensa](https://pypi.python.org/pypi/pyopenmensa) ([documentation](http://pyom.devtation.de), [repo](https://github.com/mswart/pyopenmensa)) to generate the XML feed and for some help for the parsing itself.
+At the moment all providers using [PyOpenMensa] ([documentation](http://pyom.devtation.de), [repo](https://github.com/mswart/pyopenmensa)) to generate the XML feed and for some help for the parsing itself.
 
-As many meal information are only available online as HTML, [Beautiful Soup 4](http://www.crummy.com/software/BeautifulSoup/) is used as a robust but easy to use HTML parser.
+As many meal information are only available online as HTML, [Beautiful Soup 4] is used as a robust but easy to use HTML parser.
 
 
 ## Get started
@@ -40,9 +40,9 @@ As many meal information are only available online as HTML, [Beautiful Soup 4](h
         git clone --recurse-submodules git://github.com/mswart/openmensa-parsers
 
 2. Install the dependecies:
-   * [Python 3](https://www.python.org/)
-   * [Beautiful Soup 4](http://www.crummy.com/software/BeautifulSoup/) - needed for most parsers/providers.
-   * [python-lxml](http://lxml.de/) Some parsers using the `lxml` backend of Beautiful Soup, so you might need the Python `lxml` module/extension.
+   * [Python 3]
+   * [Beautiful Soup 4] - needed for most parsers/providers.
+   * [python-lxml] Some parsers using the `lxml` backend of Beautiful Soup, so you might need the Python `lxml` module/extension.
 
 3. Try some parsers
 
@@ -68,8 +68,16 @@ As many meal information are only available online as HTML, [Beautiful Soup 4](h
 
 ## Further questions
 
-* Read the [OpenMensa Documentation](http://doc.openmensa.org)
+* Read the [OpenMensa Documentation]
 * Ask at the OpenMensa IRC channel `freenode#openmensa`
 * The [add howto for developers of new parser](https://github.com/mswart/openmensa-parsers/issues/2) issue may be helpful.
 * Open an issue
 
+[OpenMensa]: http://openmensa.org
+[OpenMensa Documentation]: http://doc.openmensa.org
+[feed documentation]: http://doc.openmensa.org/feed/v2/
+[config.py]: config.py
+[PyOpenMensa]: https://pypi.python.org/pypi/pyopenmensa
+[Beautiful Soup 4]: http://www.crummy.com/software/BeautifulSoup/
+[python-lxml]: http://lxml.de/
+[Python 3]: https://www.python.org/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The [config.py] contains a list of all known providers and it's canteens (plus t
 
 ## Common implementation details of providers
 
-At the moment all providers using [PyOpenMensa] ([documentation](https://pyopenmensa.readthedocs.io/), [repo](https://github.com/mswart/pyopenmensa)) to generate the XML feed and for some help for the parsing itself.
+At the moment all providers are using [PyOpenMensa] ([documentation](https://pyopenmensa.readthedocs.io/), [repo](https://github.com/mswart/pyopenmensa)) to generate the XML feed and for some help for the parsing itself.
 
 As many meal information are only available online as HTML, [Beautiful Soup 4] is used as a robust but easy to use HTML parser.
 
@@ -39,10 +39,10 @@ As many meal information are only available online as HTML, [Beautiful Soup 4] i
 
         git clone --recurse-submodules git://github.com/mswart/openmensa-parsers
 
-2. Install the dependecies:
+2. Install the dependencies:
    * [Python 3]
    * [Beautiful Soup 4] - needed for most parsers/providers.
-   * [python-lxml] Some parsers using the `lxml` backend of Beautiful Soup, so you might need the Python `lxml` module/extension.
+   * [python-lxml] Some parsers use the `lxml` backend of Beautiful Soup, so you might need the Python `lxml` module/extension.
 
 3. Try some parsers
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The [config.py] contains a list of all known providers and it's canteens (plus t
 
 ## Common implementation details of providers
 
-At the moment all providers using [PyOpenMensa] ([documentation](http://pyom.devtation.de), [repo](https://github.com/mswart/pyopenmensa)) to generate the XML feed and for some help for the parsing itself.
+At the moment all providers using [PyOpenMensa] ([documentation](https://pyopenmensa.readthedocs.io/), [repo](https://github.com/mswart/pyopenmensa)) to generate the XML feed and for some help for the parsing itself.
 
 As many meal information are only available online as HTML, [Beautiful Soup 4] is used as a robust but easy to use HTML parser.
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ As many meal information are only available online as HTML, [Beautiful Soup 4] i
 * The [add howto for developers of new parser](https://github.com/mswart/openmensa-parsers/issues/2) issue may be helpful.
 * Open an issue
 
-[OpenMensa]: http://openmensa.org
-[OpenMensa Documentation]: http://doc.openmensa.org
-[feed documentation]: http://doc.openmensa.org/feed/v2/
+[OpenMensa]: https://openmensa.org
+[OpenMensa Documentation]: https://doc.openmensa.org
+[feed documentation]: https://doc.openmensa.org/feed/v2/
 [config.py]: config.py
 [PyOpenMensa]: https://pypi.python.org/pypi/pyopenmensa
-[Beautiful Soup 4]: http://www.crummy.com/software/BeautifulSoup/
+[Beautiful Soup 4]: https://www.crummy.com/software/BeautifulSoup/
 [python-lxml]: http://lxml.de/
 [Python 3]: https://www.python.org/


### PR DESCRIPTION
The `config.py` link was broken and there was a typo `Corrections Wellcome`. Additionally changes the inline links to reference style, where appropriate.