### PR TITLE
Add simple metadata endpoint to HandleSource parsers

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ import json
 
 from bs4 import BeautifulSoup
 
-from pyopenmensa.feed import LazyBuilder
+from pyopenmensa.feed import LazyBuilder, Feed
 
 
 class Request(object):
@@ -168,7 +168,39 @@ class HandlerSource(Source):
         self.args = args
         self.kwargs = kwargs
 
+    def metadata(self, request):
+        meta = LazyBuilder(version=self.parser.version)
+
+        meta.feeds.append(Feed(
+            name='today',
+            hour='8-14',
+            url='/'.join([request.host, self.parser.name, self.name, 'today.xml']),
+            priority=0,
+            source=None,
+            dayOfMonth='*',
+            dayOfWeek='*',
+            minute='0',
+            retry=None
+        ))
+
+        meta.feeds.append(Feed(
+            name='full',
+            hour='8',
+            url='/'.join([request.host, self.parser.name, self.name, 'full.xml']),
+            priority=0,
+            source=None,
+            dayOfMonth='*',
+            dayOfWeek='*',
+            minute='0',
+            retry=None
+        ))
+
+        return meta.toXMLFeed()
+
     def parse(self, request, feed):
+        if feed == 'metadata.xml':
+            return self.metadata(request)
+
         return self.handler(*self.args, today=feed == 'today.xml', **self.kwargs)
 
 


### PR DESCRIPTION
```
This commit adds a metadata.xml handler for HandleSource. It will generate
a plain metadata XML with a default full and today feed URLs.

Metadata will only include the feed definitions and no canteen information to
avoid overriding data. This means (new) canteens *cannot* be created by adding
metadata targets only.

Closes openmensa/openmensa#35
```

This should fix openmensa/openmensa#35 while keeping the Index-URLs for parses build with HandleSource. The next update from OpenMensa should fetch the new metadata and update existing canteens the default today and full feeds.