### PR TITLE
Karlsruhe: Notes and closed days

### DIFF
--- a/parsers/karlsruhe.py
+++ b/parsers/karlsruhe.py
@@ -82,8 +82,10 @@ extraLegend = {
     'ICON=4457_icon_mensavital.jpg': 'Mensa Vital'
 }
 
+
 def icon(src):
     return 'ICON=' + src.rsplit('/', 1).pop()
+
 
 def parse_week(canteen, url, place_class=None):
     content = urlopen(url).read().decode('utf-8', errors='ignore')
@@ -147,10 +149,12 @@ def parse_week(canteen, url, place_class=None):
                         closed_date_match = closed_regex.search(meal_tr.contents[1].text)
                     continue
                 found_meals = True
-                if meal_tr.contents[1].find('span'):
-                    name = meal_tr.contents[1].find('span').text  # Name without notes in <sup>
+                td1 = meal_tr.contents[1]
+                span = td1.find('span')
+                if span:
+                    name = span.text  # Name without notes in <sup>
                 else:
-                    name = meal_tr.contents[1].text  # Fallback value: whole line
+                    name = td1.text  # Fallback value: whole line
 
                 # Add notes from <sup>[Ab,Cd,Ef]</sup>
                 sup = meal_tr.find('sup')
@@ -161,9 +165,10 @@ def parse_week(canteen, url, place_class=None):
                 else:
                     notes = []
 
-                # Find icons and convert to notes
-                if meal_tr.contents[0].find('img'):
-                    key = icon(meal_tr.contents[0].find('img')['src'])
+                # Find and convert icons to notes
+                img = meal_tr.find('img')
+                if img:
+                    key = icon(img['src'])
                     if key in extraLegend:
                         notes.insert(0, extraLegend[key])
 

--- a/parsers/karlsruhe.py
+++ b/parsers/karlsruhe.py
@@ -183,15 +183,18 @@ def parse_week(canteen, url, place_class=None):
 
             now = datetime.datetime.now()
             year_from = year_to = now.year
-
+            month_from = int(match_from.split(".")[1])
+            month_to = int(match_to.split(".")[1])
             if now.month > 9:
-                if now.month > int(match_to.split(".")[1]):
+                if now.month > month_to:
                     year_to += 1
-                    if now.month > int(match_from.split(".")[1]):
+                    if now.month > month_from:
                         year_from += 1
 
             fromdate = datetime.datetime.strptime('%s%d' % (match_from, year_from), '%d.%m.%Y')
             todate = datetime.datetime.strptime('%s%d' % (match_to, year_to), '%d.%m.%Y')
+            if fromdate < now:
+                fromdate = now
 
             while fromdate <= todate:
                 canteen.setDayClosed(fromdate.strftime('%d.%m.%Y'))

--- a/parsers/karlsruhe.py
+++ b/parsers/karlsruhe.py
@@ -180,14 +180,19 @@ def parse_week(canteen, url, place_class=None):
             # let's assume the whole canteen is closed on the mentioned dates
             match_from = closed_date_match.group("from")
             match_to = closed_date_match.group("to")
+
             now = datetime.datetime.now()
             year_from = year_to = now.year
-            if now.month < int(match_from.split(".")[1]):
-                year_from += 1
-            if now.month < int(match_to.split(".")[1]):
-                year_to += 1
+
+            if now.month > 9:
+                if now.month > int(match_to.split(".")[1]):
+                    year_to += 1
+                    if now.month > int(match_from.split(".")[1]):
+                        year_from += 1
+
             fromdate = datetime.datetime.strptime('%s%d' % (match_from, year_from), '%d.%m.%Y')
             todate = datetime.datetime.strptime('%s%d' % (match_to, year_to), '%d.%m.%Y')
+
             while fromdate <= todate:
                 canteen.setDayClosed(fromdate.strftime('%d.%m.%Y'))
                 fromdate += datetime.timedelta(1)

--- a/parsers/karlsruhe.py
+++ b/parsers/karlsruhe.py
@@ -170,7 +170,7 @@ def parse_week(canteen, url, place_class=None):
                 if img:
                     key = icon(img['src'])
                     if key in extraLegend:
-                        notes.insert(0, extraLegend[key])
+                        notes.append(extraLegend[key])
 
                 canteen.addMeal(date, category, name, notes,
                                 price_regex.findall(meal_tr.contents[2].text), roles)

--- a/parsers/karlsruhe.py
+++ b/parsers/karlsruhe.py
@@ -165,16 +165,17 @@ def parse_week(canteen, url, place_class=None):
                                 price_regex.findall(meal_tr.contents[2].text), roles)
 
         if not found_meals and closed_date_match:
-            m = closed_date_match
+            match_from = closed_date_match.group(1)
+            match_to = closed_date_match.group(2)
             now = datetime.datetime.now()
             year_from = year_to = now.year
             if now.month == 12:
-                if m['from'].endswith('01.'):
+                if  match_from.endswith('01.'):
                     year_from += 1
-                if m['to'].endswith('01.'):
+                if match_to.endswith('01.'):
                     year_to += 1
-            fromdate = datetime.datetime.strptime('%s%d' % (m['from'], year_from), '%d.%m.%Y')
-            todate = datetime.datetime.strptime('%s%d' % (m['to'], year_to), '%d.%m.%Y')
+            fromdate = datetime.datetime.strptime('%s%d' % ( match_from, year_from), '%d.%m.%Y')
+            todate = datetime.datetime.strptime('%s%d' % (match_to, year_to), '%d.%m.%Y')
             while fromdate <= todate:
                 canteen.setDayClosed(fromdate.strftime('%d.%m.%Y'))
                 fromdate += datetime.timedelta(1)

--- a/parsers/karlsruhe.py
+++ b/parsers/karlsruhe.py
@@ -93,7 +93,6 @@ def parse_week(canteen, url, place_class=None):
         # Update legend
         legend_content = legend.find('br').parent
         current_img = None
-        extraLegend2 = {}
         for child in legend_content.children:
             if isinstance(child, str):
                 if current_img:

--- a/parsers/karlsruhe.py
+++ b/parsers/karlsruhe.py
@@ -9,18 +9,85 @@ from pyopenmensa.feed import OpenMensaCanteen
 
 day_regex = re.compile('(?P<date>\d{4}-\d{2}-\d{2})')
 price_regex = re.compile('(?P<price>\d+[,.]\d{2}) ?€')
+notes_regex = re.compile('\[(?:(([A-Za-z0-9]+),?)+)\]$')
 
 roles = ('student', 'other', 'employee', 'pupil')
 
+extraLegend = {
+    # Source: https://www.sw-ka.de/media/?file=4458_liste_aller_gesetzlich_ausweisungspflichtigen_zusatzstoffe_und_allergene_fuer_website_160218.pdf&download
+    '1': 'mit Farbstoff',
+    '2': 'mit Konservierungsstoff',
+    '3': 'mit Antioxidationsmittel',
+    '4': 'mit Geschmacksverstärker',
+    '5': 'mit Phosphat',
+    '6': 'Oberfläche gewachst',
+    '7': 'geschwefelt',
+    '8': 'Oliven geschwärzt',
+    '9': 'mit Süßungsmitteln',
+    '10': 'kann bei übermäßigem Verzehr abführend wirken',
+    '11': 'enthält eine Phenylalaninquelle',
+    '12': 'kann Restalkohol enthalten',
+    '14': 'aus Fleischstücken zusammengefügt',
+    '15': 'mit kakaohaltiger Fettglasur',
+    '27': 'aus Fischstücken zusammengefügt',
+    'Ca': 'Cashewnüsse',
+    'Di': 'Dinkel',
+    'Ei': 'Eier',
+    'Er': 'Erdnüsse',
+    'Fi': 'Fisch',
+    'Ge': 'Gerste',
+    'Gl': 'Glutenhaltiges Getreide',
+    'Hf': 'Hafer',
+    'Ha': 'Haselnüsse',
+    'Ka': 'Kamut',
+    'Kr': 'Krebstiere',
+    'Lu': 'Lupine',
+    'Ma': 'Mandeln',
+    'ML': 'Milch/Laktose',
+    'Nu': 'Schalenfrüchte/Nüsse',
+    'Pa': 'Paranüsse',
+    'Pe': 'Pekannüsse',
+    'Pi': 'Pistazie',
+    'Qu': 'Queenslandnüsse/Macadamianüsse',
+    'Ro': 'Roggen',
+    'Sa': 'Sesam',
+    'Se': 'Sellerie',
+    'Sf': 'Schwefeldioxid/Sulfit',
+    'Sn': 'Senf',
+    'So': 'Soja',
+    'Wa': 'Walnüsse',
+    'We': 'Weizen',
+    'Wt': 'Weichtiere',
+    'LAB': 'mit tierischem Lab',
+    'GEL': 'mit Gelatine',
+    'ICON=r_2.gif': 'enthält Rindfleisch',
+    'ICON=2802_r_2.gif': 'enthält Rindfleisch',
+    'ICON=ra_2.gif': 'enthält regionales Rindfleisch aus artgerechter Tierhaltung',
+    'ICON=3302_rind_artgerecht.jpg': 'enthält regionales Rindfleisch aus artgerechter Tierhaltung',
+    'ICON=2801_s_2.gif': 'enthält Schweinefleisch',
+    'ICON=sa_2.gif': 'enthält regionales Schweinefleisch aus artgerechter Tierhaltung',
+    'ICON=4456_schwein_artgerecht.jpg': 'enthält regionales Schweinefleisch aus artgerechter Tierhaltung',
+    'ICON=vegetarian_2.gif': 'vegetarisches Gericht',
+    'ICON=2803_vegetarian_2.gif': 'vegetarisches Gericht',
+    'ICON=vegan_2.gif': 'veganes Gericht',
+    'ICON=2804_vegan_2.gif': 'veganes Gericht',
+    'ICON=bio_2.gif': 'kontrolliert biologischer Anbau mit EU Bio-Siegel / DE-Öko-007 Kontrollstelle',
+    'ICON=3304_bio_neu_small.jpg': 'kontrolliert biologischer Anbau mit EU Bio-Siegel / DE-Öko-007 Kontrollstelle',
+    'ICON=m_2.gif': 'MSC aus zertifizierter Fischerei',
+    'ICON=2903_msc_logo_web.jpg': 'MSC aus zertifizierter Fischerei',
+    'ICON=mv_2.gif': 'Mensa Vital',
+    'ICON=4457_icon_mensavital.jpg': 'Mensa Vital'
+}
+
+def icon(src):
+    return 'ICON=' + src.rsplit('/', 1).pop()
 
 def parse_week(canteen, url, place_class=None):
     content = urlopen(url).read().decode('utf-8', errors='ignore')
     document = parse(content, features='lxml')
-    legends = document.find_all('div', {'class': 'legende'})
-    if len(legends) > 0:
-        extraLegend = {int(v[0]): v[1] for v in reversed(legend_regex.findall(legends[0].text))}
-    else:
-        extraLegend = {}
+    legend = document.find('div', {'id': 'leg'})
+    if legend:
+        pass  # TODO Update legend
 
     if place_class:
         document = document.find(id=place_class)
@@ -51,9 +118,23 @@ def parse_week(canteen, url, place_class=None):
                 if len(list(meal_tr.children)) != 3:
                     #print('skipping category, unable to parse meal_table: {} tds'.format(len(list(meal_tr.children))))
                     continue
-                name = meal_tr.contents[1].text
-                # notes, to do
-                canteen.addMeal(date, category, name, [],
+                if meal_tr.contents[1].find('span'):
+                    name = meal_tr.contents[1].find('span').text  # Name without notes
+                else:
+                    name = meal_tr.contents[1].text
+                # Add notes:
+                sup = meal_tr.find('sup')
+                if sup:
+                    keys = sup.text.strip()[1:-1] if sup.text and sup.text.startswith('[') > 3 else ''
+                    notes = [extraLegend[key] if key in extraLegend else key for key in keys.split(',') if key]
+                else:
+                    notes = []
+                if meal_tr.contents[0].find('img'):
+                    key = icon(meal_tr.contents[0].find('img')['src'])
+                    if key in extraLegend:
+                        notes.insert(0, extraLegend[key])
+
+                canteen.addMeal(date, category, name, notes,
                                 price_regex.findall(meal_tr.contents[2].text), roles)
 
 

--- a/parsers/karlsruhe.py
+++ b/parsers/karlsruhe.py
@@ -95,7 +95,7 @@ def parse_week(canteen, url, place_class=None):
         current_img = None
         for child in legend_content.children:
             if isinstance(child, str):
-                if current_img:
+                if current_img is not None:
                     s = child.strip()
                     if s.startswith('- '):
                         s = s[2:].strip()


### PR DESCRIPTION
- The meal names looked liked this 
  `Scharfe Sombrero - Reispfanne mit Kalbfleischbällchen[3,Ei,Se,We]`
  I moved the footnotes `[3,Ei,Se,We]` from the name and to the notes. 
  The footnotes and the little icons are mapped to their explanations. Mapping comes from a hard-coded mapping from a pdf and also from the legend on the website
- If there is a text like `Geschlossen von: Montag 18.02. - Freitag 29.03.` the corresponding dates are marked with **setDayClosed()**