### PR TITLE
Thueringen redesign

### DIFF
--- a/parsers/thueringen.py
+++ b/parsers/thueringen.py
@@ -6,133 +6,107 @@ from datetime import datetime, timedelta, date
 from pyopenmensa.feed import LazyBuilder
 import ssl
 
-amount_regex = re.compile('\d{1,2},\d{1,2}')
-
-
-def find_start_date(document):
-	calendar_week_regex = re.compile('\d{4}-\d{1,2}$')
-
-	return document.find('option', value=calendar_week_regex, selected=True)
-
-
-def parse_start_date(document):
-	week_start_end_date_regex = re.compile('\d{1,2}\.\d{1,2}\.\d{4}')
-
-	option = find_start_date(document)
-	start_date_str = week_start_end_date_regex.search(option.text)
-
-	return datetime.strptime(start_date_str.group(), '%d.%m.%Y').date()
-
-
-def parse_available_weeks(document):
-	sel_week = document.find('select', {"name": 'selWeek'})
-
-	options = sel_week.find_all('option')
-
-	for option in options:
-		week = option['value']
-		if week != '0':
-			yield week
-
-
-def parse_fees(document):
-	fees_regex = re.compile('Bedienstete.*')
-
-	fees = document.find_all('p', class_='MsoNormal', string=fees_regex)
-
-	for fee in fees:
-		fee_strings = fees_regex.findall(fee.text)
-		for amount_candidate in fee_strings:
-			amount_strings = amount_regex.findall(amount_candidate)
-			if len(amount_strings) != 2:
-				continue
-
-			employees_fee = float(amount_strings[0].replace(',', '.'))
-			guests_fee = float(amount_strings[1].replace(',', '.'))
-			return employees_fee, guests_fee
-
-	return None, None
-
-
-def parse_ingredients(document):
-	groups_regex = re.compile('([\w\d*]+):\s+(.*)')
-	groups = dict()
-
-	for table in document.select('div.kontextbox > table:nth-of-type(1)'):
-		for s in table.stripped_strings:
-			g = groups_regex.search(s)
-			if g is not None:
-				groups[g.group(1)] = g.group(2).strip()
-
-	return groups
-
-
-def parse_meals(day, groups):
-	ingredients_regex = re.compile('Inhalt:.*')
-
-	meals_t_rows = day.find_all('tr')
-
-	for meal_data in meals_t_rows:
-		meal_t_datas = meal_data.find_all('td')
-		if len(meal_t_datas) != 3:
-			continue
-
-		category = meal_t_datas[0].text
-		notes = []
-		ingredients = ingredients_regex.findall(meal_t_datas[1].text)
-
-		if len(ingredients) > 0:
-			ingredients_list = ingredients[0][8:].strip().split(',')
-
-			notes = [groups[note] for note in ingredients_list if note in groups]
-
-		main_dish = ingredients_regex.sub('', meal_t_datas[1].text).strip()
-
-		students_fee_string = amount_regex.findall(meal_t_datas[2].text)
-		if len(students_fee_string) != 1:
-			continue
-
-		students_fee = float(students_fee_string[0].replace(',', '.'))
-		costs = {'student': students_fee}
-
-		# Skip empty meals
-		if len(main_dish) == 0:
-			continue
-
-		yield (main_dish, notes, costs, category)
-
-
-def parse_meals_for_canteen(document, canteen, employees_fee, guests_fee, groups, today):
-	days_regex = re.compile('day_\d$')
-	mensa_start_date = parse_start_date(document)
-
-	day_divs = document.find_all('div', id=days_regex)
-
-	for day in day_divs:
-		day_id = int(day['id'][-1:])
-
-		current_date = mensa_start_date + timedelta(days=day_id - 2)
-
-		meals = parse_meals(day, groups)
-		for meal in meals:
-			main_dish, notes, costs, category = meal
-
-			if employees_fee is not None:
-				costs['employee'] = costs['student'] + employees_fee
-			if guests_fee is not None:
-				costs['other'] = costs['student'] + guests_fee
-			if today and current_date != date.today():
-				continue
-
-			canteen.addMeal(current_date, category, main_dish, notes, costs,
-							None)
+#amount_regex = re.compile('\d{1,2},\d{1,2}')
+#
+#
+#def parse_fees(document):
+#	fees_regex = re.compile('Bedienstete.*')
+#
+#	fees = document.find_all('p', class_='MsoNormal', string=fees_regex)
+#
+#	for fee in fees:
+#		fee_strings = fees_regex.findall(fee.text)
+#		for amount_candidate in fee_strings:
+#			amount_strings = amount_regex.findall(amount_candidate)
+#			if len(amount_strings) != 2:
+#				continue
+#
+#			employees_fee = float(amount_strings[0].replace(',', '.'))
+#			guests_fee = float(amount_strings[1].replace(',', '.'))
+#			return employees_fee, guests_fee
+#
+#	return None, None
+#
+#
+#def parse_ingredients(document):
+#	groups_regex = re.compile('([\w\d*]+):\s+(.*)')
+#	groups = dict()
+#
+#	for table in document.select('div.kontextbox > table:nth-of-type(1)'):
+#		for s in table.stripped_strings:
+#			g = groups_regex.search(s)
+#			if g is not None:
+#				groups[g.group(1)] = g.group(2).strip()
+#
+#	return groups
+#
+#
+#def parse_meals(day, groups):
+#	ingredients_regex = re.compile('Inhalt:.*')
+#
+#	meals_t_rows = day.find_all('tr')
+#
+#	for meal_data in meals_t_rows:
+#		meal_t_datas = meal_data.find_all('td')
+#		if len(meal_t_datas) != 3:
+#			continue
+#
+#		category = meal_t_datas[0].text
+#		notes = []
+#		ingredients = ingredients_regex.findall(meal_t_datas[1].text)
+#
+#		if len(ingredients) > 0:
+#			ingredients_list = ingredients[0][8:].strip().split(',')
+#
+#			notes = [groups[note] for note in ingredients_list if note in groups]
+#
+#		main_dish = ingredients_regex.sub('', meal_t_datas[1].text).strip()
+#
+#		students_fee_string = amount_regex.findall(meal_t_datas[2].text)
+#		if len(students_fee_string) != 1:
+#			continue
+#
+#		students_fee = float(students_fee_string[0].replace(',', '.'))
+#		costs = {'student': students_fee}
+#
+#		# Skip empty meals
+#		if len(main_dish) == 0:
+#			continue
+#
+#		yield (main_dish, notes, costs, category)
+#
+#
+#def parse_meals_for_canteen(document, canteen, employees_fee, guests_fee, groups, today):
+#	days_regex = re.compile('day_\d$')
+#	mensa_start_date = parse_start_date(document)
+#
+#	day_divs = document.find_all('div', id=days_regex)
+#
+#	for day in day_divs:
+#		day_id = int(day['id'][-1:])
+#
+#		current_date = mensa_start_date + timedelta(days=day_id - 2)
+#
+#		meals = parse_meals(day, groups)
+#		for meal in meals:
+#			main_dish, notes, costs, category = meal
+#
+#			if employees_fee is not None:
+#				costs['employee'] = costs['student'] + employees_fee
+#			if guests_fee is not None:
+#				costs['other'] = costs['student'] + guests_fee
+#			if today and current_date != date.today():
+#				continue
+#
+#			canteen.addMeal(current_date, category, main_dish, notes, costs,
+#							None)
 
 class Canteen(EasySource):
-	BASE_URL = 'https://www.stw-thueringen.de/deutsch/mensen/einrichtungen/'
+	ENDPOINT_URL = 'https://www.stw-thueringen.de/xhr/loadspeiseplan.html'
 
-	def __init__(self, *args, suffix):
+	def __init__(self, *args, canteen_id):
 		super().__init__(*args)
-		self.suffix = suffix
+		self.canteen_id = canteen_id
 
 		# www.stw-thueringen.de is currently not providing the intermediate
 		# cert in its chain, so we just disable any cert checking, see:
@@ -141,23 +115,33 @@ class Canteen(EasySource):
 		self.tls_context.check_hostname = False
 		self.tls_context.verify_mode = ssl.CERT_NONE
 
-	def parse_url(self, url, today=False):
-		document = self.parse_remote(url, tls_context=self.tls_context)
+	def parse_single_date(self, date):
+		post_args = [
+			('resources_id', self.canteen_id),
+			('date', date.strftime('%d.%m.%Y'))
+		]
+		print('fetching date ' + post_args[1][1])
+		document = self.parse_remote(self.ENDPOINT_URL, args=post_args, tls_context=self.tls_context)
+		#print(document)
+		return True
 
-		employees_fee, guests_fee = parse_fees(document)
-		groups = parse_ingredients(document)
-
-		# for the case that the start date is not auto set by the page e.g. on weekends
-		noskip = find_start_date(document) is None
-		available_weeks = parse_available_weeks(document)
-
-		for idx, week in enumerate(available_weeks):
-			if idx > 0 or noskip:
-				document = self.parse_remote("{}?selWeek={}".format(url, week), tls_context=self.tls_context)
-
-			parse_meals_for_canteen(document, self.feed, employees_fee, guests_fee, groups, today)
+	def parse_data(self, start_date, today=False):
+		not_available_count = 0
+		
+		# ignore weekends
+		while not_available_count <= 2:
+			if self.parse_single_date(start_date):
+				not_available_count = 0
+			else:
+				# no meals available
+				not_available_count += 1
+			# only fetch a single day
 			if today:
 				break
+			# increment day
+			start_date += timedelta(days=1)
+
+		print('--------------------------')
 
 	def extract_metadata(self):
 		city = self.suffix.split('/')[0]
@@ -189,36 +173,38 @@ class Canteen(EasySource):
 
 	@Source.today_feed
 	def today(self, request):
-		self.parse_url(self.BASE_URL + self.suffix, True)
+		day = datetime.now()
+		self.parse_data(day, True)
 		return self.feed.toXMLFeed()
 
 	@Source.full_feed
 	def full(self, request):
-		self.parse_url(self.BASE_URL + self.suffix, False)
+		day = datetime.now()
+		self.parse_data(day, False)
 		return self.feed.toXMLFeed()
 
-parser = Parser('thueringen', version='1.0')
-Canteen('ei-wartenberg', parser, suffix='eisenach/mensa-am-wartenberg-2.html')
-Canteen('ef-nordhaeuser', parser, suffix='erfurt/mensa-nordhaeuser-strasse.html')
-Canteen('ef-altonaer', parser, suffix='erfurt/mensa-altonaer-strasse.html')
-Canteen('ef-schlueterstr', parser, suffix='erfurt/cafeteria-schlueterstrasse.html')
-Canteen('ef-leipzigerstr', parser, suffix='erfurt/cafeteria-leipziger-strasse.html')
-Canteen('ge-freundschaft', parser, suffix='gera/mensa-weg-der-freundschaft.html')
-Canteen('il-ehrenberg', parser, suffix='ilmenau/mensa-ehrenberg.html')
-Canteen('il-cafeteria', parser, suffix='ilmenau/cafeteria-mensa-ehrenberg.html')
-Canteen('il-nanoteria', parser, suffix='ilmenau/cafeteria-nanoteria.html')
-Canteen('il-roentgen', parser, suffix='ilmenau/cafeteria-roentgenbau.html')
-Canteen('je-zeiss', parser, suffix='jena/mensa-carl-zeiss-promenade.html')
-Canteen('je-eah', parser, suffix='jena/cafeteria-eah.html')
-Canteen('je-ernstabbe', parser, suffix='jena/mensa-ernst-abbe-platz.html')
-Canteen('je-vegeTable', parser, suffix='jena/vegetable.html')
-Canteen('je-rosen', parser, suffix='jena/cafeteria-zur-rosen.html')
-Canteen('je-philosophen', parser, suffix='jena/mensa-philosophenweg.html')
-Canteen('je-haupt', parser, suffix='jena/cafeteria-uni-hauptgebaeude.html')
-Canteen('je-bib', parser, suffix='jena/cafeteria-bibliothek-thulb.html')
-Canteen('nh-mensa', parser, suffix='nordhausen/mensa-nordhausen.html')
-Canteen('sk-mensa', parser, suffix='schmalkalden/mensa-schmalkalden.html')
-Canteen('we-horn', parser, suffix='weimar/cafeteria-am-horn.html')
-Canteen('we-park', parser, suffix='weimar/mensa-am-park.html')
-Canteen('we-anna', parser, suffix='weimar/cafeteria-anna-amalia-bibliothek.html')
-Canteen('we-coudray', parser, suffix='weimar/cafeteria-coudraystrasse.html')
+parser = Parser('thueringen', version='2.0')
+#Canteen('ei-wartenberg', parser, suffix='eisenach/mensa-am-wartenberg-2.html')
+#Canteen('ef-nordhaeuser', parser, suffix='erfurt/mensa-nordhaeuser-strasse.html')
+#Canteen('ef-altonaer', parser, suffix='erfurt/mensa-altonaer-strasse.html')
+#Canteen('ef-schlueterstr', parser, suffix='erfurt/cafeteria-schlueterstrasse.html')
+#Canteen('ef-leipzigerstr', parser, suffix='erfurt/cafeteria-leipziger-strasse.html')
+#Canteen('ge-freundschaft', parser, suffix='gera/mensa-weg-der-freundschaft.html')
+#Canteen('il-ehrenberg', parser, suffix='ilmenau/mensa-ehrenberg.html')
+#Canteen('il-cafeteria', parser, suffix='ilmenau/cafeteria-mensa-ehrenberg.html')
+#Canteen('il-nanoteria', parser, suffix='ilmenau/cafeteria-nanoteria.html')
+#Canteen('il-roentgen', parser, suffix='ilmenau/cafeteria-roentgenbau.html')
+#Canteen('je-zeiss', parser, suffix='jena/mensa-carl-zeiss-promenade.html')
+#Canteen('je-eah', parser, suffix='jena/cafeteria-eah.html')
+#Canteen('je-ernstabbe', parser, suffix='jena/mensa-ernst-abbe-platz.html')
+#Canteen('je-vegeTable', parser, suffix='jena/vegetable.html')
+#Canteen('je-rosen', parser, suffix='jena/cafeteria-zur-rosen.html')
+Canteen('je-philosophen', parser, canteen_id=59)
+#Canteen('je-haupt', parser, suffix='jena/cafeteria-uni-hauptgebaeude.html')
+#Canteen('je-bib', parser, suffix='jena/cafeteria-bibliothek-thulb.html')
+#Canteen('nh-mensa', parser, suffix='nordhausen/mensa-nordhausen.html')
+#Canteen('sk-mensa', parser, suffix='schmalkalden/mensa-schmalkalden.html')
+#Canteen('we-horn', parser, suffix='weimar/cafeteria-am-horn.html')
+#Canteen('we-park', parser, suffix='weimar/mensa-am-park.html')
+#Canteen('we-anna', parser, suffix='weimar/cafeteria-anna-amalia-bibliothek.html')
+#Canteen('we-coudray', parser, suffix='weimar/cafeteria-coudraystrasse.html')

--- a/parsers/thueringen.py
+++ b/parsers/thueringen.py
@@ -71,7 +71,6 @@ class Canteen(EasySource):
 			('resources_id', self.canteen_id),
 			('date', date.strftime('%d.%m.%Y'))
 		]
-		print('fetching date ' + post_args[1][1])
 		document = self.parse_remote(self.ENDPOINT_URL, args=post_args, tls_context=self.tls_context)
 		if not parse_closed(document):
 			legend = parse_legend(document)
@@ -85,20 +84,15 @@ class Canteen(EasySource):
 				elif 'Fisch' in info['misc']:
 					category = 'Fisch'
 
-				additives = 'Zusatzstoffe: ' + (', '.join((legend[item] for item in info['additives'])) if info['additives'] else 'keine')
-				allergens = 'Allergene: ' + (', '.join((legend[item] for item in info['allergens'])) if info['allergens'] else 'keine')
+				additives = 'Zusatzstoffe: ' + ', '.join((legend[item] for item in info['additives'])) if info['additives'] else 'ohne deklarationspflichtige Zusatzstoffe'
+				allergens = 'Allergene: ' + ', '.join((legend[item] for item in info['allergens'])) if info['allergens'] else ''
 				# remove information which is already present in the category
 				misc = ', '.join((item for item in info['misc'] if item not in ['Vegane Speisen', 'Vegetarische Speisen', 'Fisch']))
 
-				print(category)
-				print(name)
-				print(additives)
-				print(allergens)
-				print(misc)
-				print(prices)
-				print('-----')
-				notes = [additives, allergens]
-				# only add misc if not empty
+				notes = [additives]
+				# only add misc and allergens if not empty
+				if len(allergens):
+					notes.append(allergens)
 				if len(misc):
 					notes.append(misc)
 
@@ -122,8 +116,6 @@ class Canteen(EasySource):
 				break
 			# increment day
 			start_date += timedelta(days=1)
-
-		print('--------------------------')
 
 	def extract_metadata(self):
 		city = self.suffix.split('/')[0]

--- a/parsers/thueringen.py
+++ b/parsers/thueringen.py
@@ -117,34 +117,6 @@ class Canteen(EasySource):
 			# increment day
 			start_date += timedelta(days=1)
 
-	def extract_metadata(self):
-		city = self.suffix.split('/')[0]
-		doc = self.parse_remote(self.BASE_URL + city, tls_context=self.tls_context)
-		data = doc.find(id='tpl_form')
-
-		# The map this data was intended for was removed along with
-		# all data, so this will always be None currently.
-		if data is None:
-			return
-
-		link = data.find(attrs={
-			'name': re.compile(r'^link_'),
-			'value': re.compile(r'{}$'.format(re.escape(self.suffix))),
-		})
-		if link is None:
-			return
-
-		number = link['name'][5:]
-		name = data.find(attrs={'name': 'title_' + number})['value']
-		address = data.find(attrs={'name': 'adresse_' + number})['value']
-		location = data.find(attrs={'name': 'xy_' + number})['value']
-
-		canteen = self.feed
-		canteen.name = name
-		canteen.address = re.sub(r'^(.*)\s+([^\s]+)\s+(\d{5})\s*$', r'\1, \3 \2', address)
-		canteen.city = city.capitalize()
-		canteen.location(*location.split(','))
-
 	@Source.today_feed
 	def today(self, request):
 		day = date.today()
@@ -158,27 +130,26 @@ class Canteen(EasySource):
 		return self.feed.toXMLFeed()
 
 parser = Parser('thueringen', version='2.0')
-#Canteen('ei-wartenberg', parser, suffix='eisenach/mensa-am-wartenberg-2.html')
-#Canteen('ef-nordhaeuser', parser, suffix='erfurt/mensa-nordhaeuser-strasse.html')
-#Canteen('ef-altonaer', parser, suffix='erfurt/mensa-altonaer-strasse.html')
-#Canteen('ef-schlueterstr', parser, suffix='erfurt/cafeteria-schlueterstrasse.html')
-#Canteen('ef-leipzigerstr', parser, suffix='erfurt/cafeteria-leipziger-strasse.html')
-#Canteen('ge-freundschaft', parser, suffix='gera/mensa-weg-der-freundschaft.html')
-#Canteen('il-ehrenberg', parser, suffix='ilmenau/mensa-ehrenberg.html')
-#Canteen('il-cafeteria', parser, suffix='ilmenau/cafeteria-mensa-ehrenberg.html')
-#Canteen('il-nanoteria', parser, suffix='ilmenau/cafeteria-nanoteria.html')
-#Canteen('il-roentgen', parser, suffix='ilmenau/cafeteria-roentgenbau.html')
-#Canteen('je-zeiss', parser, suffix='jena/mensa-carl-zeiss-promenade.html')
-#Canteen('je-eah', parser, suffix='jena/cafeteria-eah.html')
-#Canteen('je-ernstabbe', parser, suffix='jena/mensa-ernst-abbe-platz.html')
-#Canteen('je-vegeTable', parser, suffix='jena/vegetable.html')
-#Canteen('je-rosen', parser, suffix='jena/cafeteria-zur-rosen.html')
+Canteen('ei-wartenberg', parser, canteen_id=69)
+Canteen('ef-nordhaeuser', parser, canteen_id=44)
+Canteen('ef-altonaer', parser, canteen_id=47)
+Canteen('ef-schlueterstr', parser, canteen_id=51)
+Canteen('ef-leipzigerstr', parser, canteen_id=52)
+Canteen('ge-freundschaft', parser, canteen_id=67)
+Canteen('il-ehrenberg', parser, canteen_id=46)
+Canteen('il-cafeteria', parser, canteen_id=53)
+Canteen('il-nanoteria', parser, canteen_id=55)
+Canteen('il-roentgen', parser, canteen_id=57)
+Canteen('je-zeiss', parser, canteen_id=58)
+Canteen('je-eah', parser, canteen_id=61)
+Canteen('je-ernstabbe', parser, canteen_id=41)
+Canteen('je-vegeTable', parser, canteen_id=60)
+Canteen('je-rosen', parser, canteen_id=63)
 Canteen('je-philosophen', parser, canteen_id=59)
-#Canteen('je-haupt', parser, suffix='jena/cafeteria-uni-hauptgebaeude.html')
-#Canteen('je-bib', parser, suffix='jena/cafeteria-bibliothek-thulb.html')
-#Canteen('nh-mensa', parser, suffix='nordhausen/mensa-nordhausen.html')
-#Canteen('sk-mensa', parser, suffix='schmalkalden/mensa-schmalkalden.html')
-#Canteen('we-horn', parser, suffix='weimar/cafeteria-am-horn.html')
-#Canteen('we-park', parser, suffix='weimar/mensa-am-park.html')
-#Canteen('we-anna', parser, suffix='weimar/cafeteria-anna-amalia-bibliothek.html')
-#Canteen('we-coudray', parser, suffix='weimar/cafeteria-coudraystrasse.html')
+Canteen('je-haupt', parser, canteen_id=64)
+Canteen('je-bib', parser, canteen_id=65)
+Canteen('nh-mensa', parser, canteen_id=71)
+Canteen('sk-mensa', parser, canteen_id=73)
+Canteen('we-park', parser, canteen_id=77)
+Canteen('we-anna', parser, canteen_id=80)
+Canteen('we-coudray', parser, canteen_id=81)


### PR DESCRIPTION
I rewrote the parser for thueringen in response to a complete redesign of their website (mentioned in  #113 ). This is my first time contributing to openmensa, so I'm not sure whether I got everything correct.

I left out the canteen metadata parsing, because the canteen information page on, for example `https://www.stw-thueringen.de/mensen/erfurt/mensa-nordh%C3%A4user-stra%C3%9Fe.html` isn't easily derived from the corresponding `canteen_id` `44`. Also the only information which is likely to change, the opening times, aren't provided in an easily machine readable format.

Also `we-horn` doesn't seem to exist anymore, so I removed it.

Since meal categories don't really exist, I chose "Vegan", "Vegetarisch", "Fisch" and everything else will be listed under "Fleisch".

I'd be glad for any feedback and look forward to having the meals available in the openmensa app again.