### PR TITLE
fix(Bamberg): remove markusplatz, add austrasse

### DIFF
--- a/parsers/wuerzburg.py
+++ b/parsers/wuerzburg.py
@@ -62,8 +62,7 @@ def parse_url(url, today=False):
 
 parser = Parser('wuerzburg', handler=parse_url,
                 shared_prefix='https://www.studentenwerk-wuerzburg.de/essen-trinken/speiseplaene/')
-#parser.define('austrasse', suffix='austrasse-bamberg.html')
-parser.define('markusplatz', suffix='interimsmensa-markusplatz-bamberg.html')
+parser.define('austrasse', suffix='mensa-austrasse-bamberg.html')
 parser.define('burse', suffix='burse-am-studentenhaus-wuerzburg.html')
 parser.define('feldkirchenstrasse', suffix='feldkirchenstrasse-bamberg.html')
 #parser.define('frankenstube', suffix='frankenstube-wuerzburg.html')


### PR DESCRIPTION
Bamberg University opened a new mensa (Austraße) and closed the Interimsmensa Markusplatz.

Source: https://www.studentenwerk-wuerzburg.de/bamberg/essen-trinken/mensen.html

I updated the parser to reflect these changes.

Could the person who added the mensa [Markusplatz](https://openmensa.org/c/902) to OpenMensa remove it and add Austraße instead?