### PR TITLE
hannover: category can also have a '&' character

### DIFF
--- a/parsers/hannover.py
+++ b/parsers/hannover.py
@@ -11,7 +11,7 @@ day_regex = re.compile('(?P<date>\d{2}\.\d{2}\.\d{4})')
 price_regex = re.compile('(?P<price>\d+[,.]\d{2})€')
 note_regex = re.compile('\((?P<number>[a-z0-9]+?)\)')
 legend_regex = re.compile('\((?P<number>\w+)\) ?(?P<value>\w+(\s+\w+)*)')
-meal_regex = re.compile('(?P<category>(\w|\s|\(|\))+):\s*(?P<meal>([^0-9\(]|[0-9]+(?!,))+)')
+meal_regex = re.compile('(?P<category>(\w|\s|&|\(|\))+):\s*(?P<meal>([^0-9\(]|[0-9]+(?!,))+)')
 
 roles = ('student', 'employee', 'other')
 


### PR DESCRIPTION
The categories from the mensa in hannover can also have a '&' character, since they introduced new 'Menülinien', which are used since [01.10.2021](https://www.studentenwerk-hannover.de/essen/menuelinien). This PR fixes this.